### PR TITLE
Fix #18: Add the blur event to the composer editing textbox before clicking discard post, so that confirmation dialog is shown when discard post shortcut is pressed.

### DIFF
--- a/public/scripts/theme/_defaults/actions.js
+++ b/public/scripts/theme/_defaults/actions.js
@@ -109,7 +109,10 @@ define("@{type.name}/@{id}/theme-defaults/actions", function () {
           composer: {
             send: function () { $("button[data-action=\"post\"]", theme.composer.getActive())[0].click(); },
             discard: function () {
-              return $("button[data-action=\"discard\"]", theme.composer.getActive())[0].click();
+              var composer = theme.composer.getActive();
+              $(".title", composer).blur();
+              $(".write", composer).blur();
+              return $("button[data-action=\"discard\"]", composer)[0].click();
             },
             closed: {
               input: function () {


### PR DESCRIPTION
Sorry for reissuing this PR, the previous PR was mistakenly committed to `master` branch.
